### PR TITLE
Fixing bugs in data loading and cpu/gpu managment

### DIFF
--- a/src/data/synthetic_data_loader.py
+++ b/src/data/synthetic_data_loader.py
@@ -13,7 +13,7 @@ logging.basicConfig(level=logging.INFO, format='%(asctime)s %(message)s')
 
 
 EFFECT_SIZE = 100
-NUM_SAMPLES = 10000
+NUM_SAMPLES = 10100
 MOVING_EFFECT = True
 RESCALE_TO_ONE = True
 

--- a/src/train.py
+++ b/src/train.py
@@ -165,7 +165,6 @@ def train(opt, healthy_dataloader, anomaly_dataloader, net_g, net_d, optim_g, op
 
                 # train with real / healthy data
                 real_cpu = data[0]
-                real_cpu.requires_grad = True
                 real_cpu = real_cpu.to(device)
 
                 net_d.zero_grad()
@@ -176,7 +175,6 @@ def train(opt, healthy_dataloader, anomaly_dataloader, net_g, net_d, optim_g, op
                 data = anomaly_data_iter.next()
 
                 anomaly_cpu = data[0]
-                anomaly_cpu.requires_grad = True
                 anomaly_cpu = anomaly_cpu.to(device)
 
                 anomaly_map = net_g(anomaly_cpu)

--- a/src/train.py
+++ b/src/train.py
@@ -192,12 +192,23 @@ def train(opt, healthy_dataloader, anomaly_dataloader, net_g, net_d, optim_g, op
                 err_d = err_d_real - err_d_anomaly_map
                 optim_d.step()
 
+            # If there weren't enough batches in dataloader to complete d_iter updates
+            # --> Exit loop, and don't do generator update
+            if i >= len(anomaly_dataloader):
+                break
+
             ############################
             # (2) Update G network
             ###########################
             for p in net_d.parameters():
                 p.requires_grad = False  # to avoid computation
             net_g.zero_grad()
+
+            data = anomaly_data_iter.next()
+            i += 1
+
+            anomaly_cpu = data[0]
+            anomaly_cpu = anomaly_cpu.to(device)
 
             anomaly_map = net_g(anomaly_cpu)
 

--- a/src/train.py
+++ b/src/train.py
@@ -230,8 +230,8 @@ def train(opt, healthy_dataloader, anomaly_dataloader, net_g, net_d, optim_g, op
             if gen_iterations % 50 == 0:
                 torch.set_grad_enabled(False)
                 anomaly_map = net_g(fixed_model_input)
-                inp = np.vstack(np.hsplit(np.hstack(fixed_model_input[:, 0]), 4))
-                img = np.vstack(np.hsplit(np.hstack(anomaly_map.data[:, 0]), 4))
+                inp = np.vstack(np.hsplit(np.hstack(fixed_model_input.cpu()[:, 0]), 4))
+                img = np.vstack(np.hsplit(np.hstack(anomaly_map.cpu().data[:, 0]), 4))
                 path = '{:}/fake_samples_{:05d}.png'.format(opt.experiment, gen_iterations)
                 plt.imsave(path, -img, cmap='gray')
                 path = '{:}/sum_samples_{:05d}.png'.format(opt.experiment, gen_iterations)


### PR DESCRIPTION
This PR consists of three commits which roughly correspond to three bugs I found:
* **Remove `requires_grad` for network input**: This was not required for anything, so I removed it, but it didn't affect the results of the model
* **Sample new batch for generator loss**: The generator loss was calculated on the last critic batch rather than with a new batch. I changed the code to sample a new batch. But it turns out the length of the data loader happened to be exactly 100 which is equal the number of critic updates. Now that we need to sample 101 batches in total, this code was running out of samples. The fact that this is possible can be considered another bug. So I added some safe guards against this happening, and changed the dataset so that it generates data loaders of 101 batches instead. 
* **Move images to cpu before saving**: There was also an issue in the validation stage that is run every 50 epochs that was preventing any images from being written, because they were still on GPU. Not sure if this issue was introduced by a later PyTorch version (I am using 1.10.2+cu102), but the code was in fact not functional out of the box. Luckily that was a simple fix.
 